### PR TITLE
New command, fixed ralsay command

### DIFF
--- a/commands/fetch/serverstats.ts
+++ b/commands/fetch/serverstats.ts
@@ -1,0 +1,48 @@
+import { CommandInteraction, Guild, PermissionsBitField } from "discord.js";
+import { Discord, Slash } from "discordx";
+
+@Discord()
+export class ServerStats {
+  @Slash({
+    name: "serverstats",
+    description: "Gathers and displays server statistics.",
+  })
+  async serverStats(interaction: CommandInteraction): Promise<void> {
+    const guild = interaction.guild as Guild;
+
+    if (!guild) {
+      await interaction.reply("This command can only be used in a server.");
+      return;
+    }
+
+    // Fetch server members and channels
+    const members = await guild.members.fetch();
+    const channels = await guild.channels.fetch();
+    const roles = await guild.roles.fetch();
+
+    // Calculate the statistics
+    const totalMembers = members.size;
+    const totalBots = members.filter((member) => member.user.bot).size;
+    const totalAdminPerms = members.filter((member) =>
+      member.permissions.has(PermissionsBitField.Flags.Administrator)
+    ).size;
+    const totalMods = members.filter((member) =>
+      member.permissions.has(PermissionsBitField.Flags.ModerateMembers)
+    ).size;
+    const totalBoosts = guild.premiumSubscriptionCount ?? 0;
+    const totalChannels = channels.size;
+    
+
+    // Respond with the collected stats
+    await interaction.editReply(
+      `**Server Statistics:**\n` +
+      `> Total Members: ${totalMembers}\n` +
+      `> Total Bots: ${totalBots}\n` +
+      `> Total Admins: ${totalAdminPerms}\n` +
+      `> Total Mods: ${totalMods}\n` +
+      `> Total Boosts: ${totalBoosts}\n` +
+      `> Total Channels: ${totalChannels}`
+    );
+  }
+}
+

--- a/commands/fetch/serverstats.ts
+++ b/commands/fetch/serverstats.ts
@@ -34,6 +34,7 @@ export class ServerStats {
     
 
     // Respond with the collected stats
+    await interaction.deferReply();
     await interaction.editReply(
       `**Server Statistics:**\n` +
       `> Total Members: ${totalMembers}\n` +

--- a/commands/fun/ralsay.ts
+++ b/commands/fun/ralsay.ts
@@ -96,6 +96,7 @@ export class RalsayCommand {
     ): Promise<void> {
         const asciiArt = generateRalsay(text);
 	
+	await interaction.deferReply();
         await interaction.editReply("```" + asciiArt + "```");
     }
 }

--- a/commands/fun/ralsay.ts
+++ b/commands/fun/ralsay.ts
@@ -95,7 +95,8 @@ export class RalsayCommand {
         interaction: CommandInteraction
     ): Promise<void> {
         const asciiArt = generateRalsay(text);
-        await interaction.reply("```" + asciiArt + "```");
+	
+        await interaction.editReply("```" + asciiArt + "```");
     }
 }
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a new 'serverstats' command to provide server statistics and fix the 'ralsay' command to handle replies correctly by deferring and editing the response.

New Features:
- Introduce a new command 'serverstats' to gather and display server statistics, including total members, bots, admins, mods, boosts, and channels.

Bug Fixes:
- Fix the 'ralsay' command by deferring the reply and then editing it to ensure proper message handling.

<!-- Generated by sourcery-ai[bot]: end summary -->